### PR TITLE
create conf file and add job to cleanup history

### DIFF
--- a/src/main/kotlin/com/kartverket/Application.kt
+++ b/src/main/kotlin/com/kartverket/Application.kt
@@ -1,22 +1,69 @@
 package com.kartverket
 
+import com.kartverket.configuration.AppConfig
 import com.kartverket.plugins.*
 import com.kartverket.util.NewSchemaMetadataMapper
+import com.typesafe.config.ConfigFactory
 import io.ktor.server.application.*
+import io.ktor.server.config.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
 
 fun main() {
     embeddedServer(
         Netty,
-        port = 8080,
-        host = "0.0.0.0",
-        module = Application::module,
+        environment = applicationEngineEnvironment {
+            config = HoconApplicationConfig(ConfigFactory.load("application.conf"))
+            module(Application::module)
+            connector {
+                port = 8080
+                host = "0.0.0.0"
+            }
+        }
     ).start(wait = true)
 }
 
+private fun loadAppConfig(config: ApplicationConfig) {
+    AppConfig.load(config)
+}
+
+fun CoroutineScope.launchCleanupJob(): Job {
+    val cleanupIntervalWeeks = AppConfig.functionHistoryCleanup.cleanupIntervalWeeks
+    val cleanupInterval: Duration = (cleanupIntervalWeeks * 7).days
+
+    return launch(Dispatchers.IO) {
+        while (isActive) {
+            try {
+                logger.info("Running scheduled cleanup every $cleanupIntervalWeeks weeks.")
+                cleanupFunctionsHistory()
+            } catch (e: Exception) {
+                logger.error("Error during function history cleanup: ${e.message}")
+            }
+            delay(cleanupInterval.inWholeMilliseconds)
+        }
+    }
+}
+
+fun cleanupFunctionsHistory() {
+    val deleteOlderThanDays = AppConfig.functionHistoryCleanup.deleteOlderThanDays
+    logger.info("Running scheduled cleanup for functions_history table. Deleting entries older than $deleteOlderThanDays days.")
+
+    Database.getConnection().use { conn ->
+        conn.prepareStatement("DELETE FROM functions_history WHERE valid_from < NOW() - INTERVAL '$deleteOlderThanDays days'")
+            .use { stmt ->
+                val deletedRows = stmt.executeUpdate()
+                logger.info("Cleanup completed. Deleted $deletedRows rows.")
+            }
+    }
+}
+
+
 fun Application.module() {
+    loadAppConfig(environment.config)
+
     Database.initDatabase()
     Database.migrate()
 
@@ -27,6 +74,8 @@ fun Application.module() {
     launch {
         NewSchemaMetadataMapper().addNewSchemaMetadata()
     }
+
+    launchCleanupJob()
 
     environment.monitor.subscribe(ApplicationStopped) {
         Database.closePool()

--- a/src/main/kotlin/com/kartverket/configuration/AppConfig.kt
+++ b/src/main/kotlin/com/kartverket/configuration/AppConfig.kt
@@ -1,0 +1,19 @@
+package com.kartverket.configuration
+
+import io.ktor.server.config.*
+
+object AppConfig {
+    lateinit var functionHistoryCleanup: FunctionHistoryCleanupConfig
+
+    fun load(config: ApplicationConfig) {
+        functionHistoryCleanup = FunctionHistoryCleanupConfig(
+            cleanupIntervalWeeks = config.propertyOrNull("functionHistoryCleanup.cleanupIntervalWeeks")?.getString()?.toInt() ?: throw IllegalStateException("Unable to initialize app config \"functionHistoryCleanup.cleanupIntervalWeeks\""),
+            deleteOlderThanDays = config.propertyOrNull("functionHistoryCleanup.deleteOlderThanDays")?.getString()?.toInt() ?: throw IllegalStateException("Unable to initialize app config \"functionHistoryCleanup.deleteOlderThanDays\""),
+        )
+    }
+}
+
+data class FunctionHistoryCleanupConfig(
+    val cleanupIntervalWeeks: Int,
+    val deleteOlderThanDays: Int
+)

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,0 +1,6 @@
+functionHistoryCleanup {
+  # How often cleanup runs in weeks
+  cleanupIntervalWeeks = 1,
+  # How old records to delete in days
+  deleteOlderThanDays = 30
+}


### PR DESCRIPTION
## Beskrivelse
Fjerne data fra functions_history

## Løsning
- La til en config fil i backend
- Lagde en cleanup job i Application.kt som sletter data fra functions_history. Den kjører nå en gang i uken og sletter data som er eldre enn 30 dager, men det kan vi endre på i config-filen.
- Måtte endre litt på main-funksjonen for å få den til å plukke opp variabler fra conf-filen

