### PR TITLE
82 bedre admin styring i frisk

### DIFF
--- a/src/main/kotlin/com/kartverket/Application.kt
+++ b/src/main/kotlin/com/kartverket/Application.kt
@@ -1,22 +1,69 @@
 package com.kartverket
 
+import com.kartverket.configuration.AppConfig
 import com.kartverket.plugins.*
 import com.kartverket.util.NewSchemaMetadataMapper
+import com.typesafe.config.ConfigFactory
 import io.ktor.server.application.*
+import io.ktor.server.config.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
 
 fun main() {
     embeddedServer(
         Netty,
-        port = 8080,
-        host = "0.0.0.0",
-        module = Application::module,
+        environment = applicationEngineEnvironment {
+            config = HoconApplicationConfig(ConfigFactory.load("application.conf"))
+            module(Application::module)
+            connector {
+                port = 8080
+                host = "0.0.0.0"
+            }
+        }
     ).start(wait = true)
 }
 
+private fun loadAppConfig(config: ApplicationConfig) {
+    AppConfig.load(config)
+}
+
+fun CoroutineScope.launchCleanupJob(): Job {
+    val cleanupIntervalWeeks = AppConfig.functionHistoryCleanup.cleanupIntervalWeeks
+    val cleanupInterval: Duration = (cleanupIntervalWeeks * 7).days
+
+    return launch(Dispatchers.IO) {
+        while (isActive) {
+            try {
+                logger.info("Running scheduled cleanup every $cleanupIntervalWeeks weeks.")
+                cleanupFunctionsHistory()
+            } catch (e: Exception) {
+                logger.error("Error during function history cleanup: ${e.message}")
+            }
+            delay(cleanupInterval.inWholeMilliseconds)
+        }
+    }
+}
+
+fun cleanupFunctionsHistory() {
+    val deleteOlderThanDays = AppConfig.functionHistoryCleanup.deleteOlderThanDays
+    logger.info("Running scheduled cleanup for functions_history table. Deleting entries older than $deleteOlderThanDays days.")
+
+    Database.getConnection().use { conn ->
+        conn.prepareStatement("DELETE FROM functions_history WHERE valid_from < NOW() - INTERVAL '$deleteOlderThanDays days'")
+            .use { stmt ->
+                val deletedRows = stmt.executeUpdate()
+                logger.info("Cleanup completed. Deleted $deletedRows rows.")
+            }
+    }
+}
+
+
 fun Application.module() {
+    loadAppConfig(environment.config)
+
     Database.initDatabase()
     Database.migrate()
 
@@ -27,6 +74,8 @@ fun Application.module() {
     launch {
         NewSchemaMetadataMapper().addNewSchemaMetadata()
     }
+
+    launchCleanupJob()
 
     environment.monitor.subscribe(ApplicationStopped) {
         Database.closePool()

--- a/src/main/kotlin/com/kartverket/configuration/AppConfig.kt
+++ b/src/main/kotlin/com/kartverket/configuration/AppConfig.kt
@@ -1,0 +1,19 @@
+package com.kartverket.configuration
+
+import io.ktor.server.config.*
+
+object AppConfig {
+    lateinit var functionHistoryCleanup: FunctionHistoryCleanupConfig
+
+    fun load(config: ApplicationConfig) {
+        functionHistoryCleanup = FunctionHistoryCleanupConfig(
+            cleanupIntervalWeeks = config.propertyOrNull("functionHistoryCleanup.cleanupIntervalWeeks")?.getString()?.toInt() ?: throw IllegalStateException("Unable to initialize app config \"functionHistoryCleanup.cleanupIntervalWeeks\""),
+            deleteOlderThanDays = config.propertyOrNull("functionHistoryCleanup.deleteOlderThanDays")?.getString()?.toInt() ?: throw IllegalStateException("Unable to initialize app config \"functionHistoryCleanup.deleteOlderThanDays\""),
+        )
+    }
+}
+
+data class FunctionHistoryCleanupConfig(
+    val cleanupIntervalWeeks: Int,
+    val deleteOlderThanDays: Int
+)

--- a/src/main/kotlin/com/kartverket/configuration/AppConfig.kt
+++ b/src/main/kotlin/com/kartverket/configuration/AppConfig.kt
@@ -4,11 +4,15 @@ import io.ktor.server.config.*
 
 object AppConfig {
     lateinit var functionHistoryCleanup: FunctionHistoryCleanupConfig
+    lateinit var superUser: SuperUser
 
     fun load(config: ApplicationConfig) {
         functionHistoryCleanup = FunctionHistoryCleanupConfig(
             cleanupIntervalWeeks = config.propertyOrNull("functionHistoryCleanup.cleanupIntervalWeeks")?.getString()?.toInt() ?: throw IllegalStateException("Unable to initialize app config \"functionHistoryCleanup.cleanupIntervalWeeks\""),
             deleteOlderThanDays = config.propertyOrNull("functionHistoryCleanup.deleteOlderThanDays")?.getString()?.toInt() ?: throw IllegalStateException("Unable to initialize app config \"functionHistoryCleanup.deleteOlderThanDays\""),
+        )
+        superUser = SuperUser(
+            teamId = config.propertyOrNull("superUser.teamId")?.getString(),
         )
     }
 }
@@ -16,4 +20,8 @@ object AppConfig {
 data class FunctionHistoryCleanupConfig(
     val cleanupIntervalWeeks: Int,
     val deleteOlderThanDays: Int
+)
+
+data class SuperUser (
+    val teamId: String?,
 )

--- a/src/main/kotlin/com/kartverket/configuration/AppConfig.kt
+++ b/src/main/kotlin/com/kartverket/configuration/AppConfig.kt
@@ -4,15 +4,11 @@ import io.ktor.server.config.*
 
 object AppConfig {
     lateinit var functionHistoryCleanup: FunctionHistoryCleanupConfig
-    lateinit var superUser: SuperUser
 
     fun load(config: ApplicationConfig) {
         functionHistoryCleanup = FunctionHistoryCleanupConfig(
             cleanupIntervalWeeks = config.propertyOrNull("functionHistoryCleanup.cleanupIntervalWeeks")?.getString()?.toInt() ?: throw IllegalStateException("Unable to initialize app config \"functionHistoryCleanup.cleanupIntervalWeeks\""),
             deleteOlderThanDays = config.propertyOrNull("functionHistoryCleanup.deleteOlderThanDays")?.getString()?.toInt() ?: throw IllegalStateException("Unable to initialize app config \"functionHistoryCleanup.deleteOlderThanDays\""),
-        )
-        superUser = SuperUser(
-            teamId = config.propertyOrNull("superUser.teamId")?.getString(),
         )
     }
 }
@@ -20,8 +16,4 @@ object AppConfig {
 data class FunctionHistoryCleanupConfig(
     val cleanupIntervalWeeks: Int,
     val deleteOlderThanDays: Int
-)
-
-data class SuperUser (
-    val teamId: String?,
 )

--- a/src/main/kotlin/com/kartverket/functions/FunctionRoutes.kt
+++ b/src/main/kotlin/com/kartverket/functions/FunctionRoutes.kt
@@ -84,7 +84,7 @@ fun Route.functionRoutes() {
                         return@delete
                     }
 
-                if (!call.hasFunctionAccess(id)) {
+                if (!call.hasFunctionAccess(id) && !call.hasSuperUserAccess()) {
                     call.respond(HttpStatusCode.Forbidden)
                     return@delete
                 }

--- a/src/main/kotlin/com/kartverket/functions/FunctionRoutes.kt
+++ b/src/main/kotlin/com/kartverket/functions/FunctionRoutes.kt
@@ -103,6 +103,17 @@ fun Route.functionRoutes() {
                 val children = FunctionService.getChildren(id)
                 call.respond(children)
             }
+            get("access") {
+                logger.info("Received get request on functions/{id}/access")
+                val id = call.parameters["id"]?.toInt() ?: run {
+                    logger.error("Invalid id parameter")
+                    call.respond(HttpStatusCode.BadRequest, "You have to supply an id")
+                    return@get
+                }
+
+                val hasAccess = call.hasFunctionAccess(id) || call.hasSuperUserAccess()
+                call.respond(hasAccess)
+            }
         }
     }
 }

--- a/src/main/kotlin/com/kartverket/functions/FunctionRoutes.kt
+++ b/src/main/kotlin/com/kartverket/functions/FunctionRoutes.kt
@@ -1,8 +1,8 @@
 package com.kartverket.functions
 
-import com.kartverket.functions.metadata.CreateFunctionMetadataDTO
 import com.kartverket.functions.metadata.FunctionMetadataService
 import com.kartverket.plugins.hasFunctionAccess
+import com.kartverket.plugins.hasSuperUserAccess
 import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.request.*
@@ -61,10 +61,10 @@ fun Route.functionRoutes() {
                         return@put
                     }
 
-//                if (!call.hasFunctionAccess(id)) {
-//                    call.respond(HttpStatusCode.Forbidden)
-//                    return@put
-//                }
+                if (!call.hasFunctionAccess(id) && !call.hasSuperUserAccess()) {
+                    call.respond(HttpStatusCode.Forbidden)
+                    return@put
+                }
 
 
                 val updatedFunction = call.receive<UpdateFunctionDto>()

--- a/src/main/kotlin/com/kartverket/functions/FunctionRoutes.kt
+++ b/src/main/kotlin/com/kartverket/functions/FunctionRoutes.kt
@@ -103,17 +103,6 @@ fun Route.functionRoutes() {
                 val children = FunctionService.getChildren(id)
                 call.respond(children)
             }
-            get("access") {
-                logger.info("Received get request on functions/{id}/access")
-                val id = call.parameters["id"]?.toInt() ?: run {
-                    logger.error("Invalid id parameter")
-                    call.respond(HttpStatusCode.BadRequest, "You have to supply an id")
-                    return@get
-                }
-
-                val hasAccess = call.hasFunctionAccess(id) || call.hasSuperUserAccess()
-                call.respond(hasAccess)
-            }
         }
     }
 }

--- a/src/main/kotlin/com/kartverket/functions/metadata/FunctionMetadataRoutes.kt
+++ b/src/main/kotlin/com/kartverket/functions/metadata/FunctionMetadataRoutes.kt
@@ -2,6 +2,7 @@ package com.kartverket.functions.metadata
 
 import com.kartverket.plugins.hasFunctionAccess
 import com.kartverket.plugins.hasMetadataAccess
+import com.kartverket.plugins.hasSuperUserAccess
 import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.plugins.*
@@ -38,6 +39,15 @@ fun Route.functionMetadataRoutes() {
                     val metadata = call.receive<CreateFunctionMetadataDTO>()
                     FunctionMetadataService.addMetadataToFunction(id, metadata)
                     call.respond(HttpStatusCode.NoContent)
+                }
+                get("access") {
+                    val id = call.parameters["id"]?.toInt() ?: run {
+                        call.respond(HttpStatusCode.BadRequest, "Invalid function id")
+                        return@get
+                    }
+
+                    val hasAccess = call.hasFunctionAccess(id) || call.hasSuperUserAccess()
+                    call.respond(hasAccess)
                 }
             }
         }

--- a/src/main/kotlin/com/kartverket/functions/metadata/FunctionMetadataRoutes.kt
+++ b/src/main/kotlin/com/kartverket/functions/metadata/FunctionMetadataRoutes.kt
@@ -2,7 +2,6 @@ package com.kartverket.functions.metadata
 
 import com.kartverket.plugins.hasFunctionAccess
 import com.kartverket.plugins.hasMetadataAccess
-import com.kartverket.plugins.hasSuperUserAccess
 import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.plugins.*
@@ -39,15 +38,6 @@ fun Route.functionMetadataRoutes() {
                     val metadata = call.receive<CreateFunctionMetadataDTO>()
                     FunctionMetadataService.addMetadataToFunction(id, metadata)
                     call.respond(HttpStatusCode.NoContent)
-                }
-                get("access") {
-                    val id = call.parameters["id"]?.toInt() ?: run {
-                        call.respond(HttpStatusCode.BadRequest, "Invalid function id")
-                        return@get
-                    }
-
-                    val hasAccess = call.hasFunctionAccess(id) || call.hasSuperUserAccess()
-                    call.respond(hasAccess)
                 }
             }
         }

--- a/src/main/kotlin/com/kartverket/microsoft/MicrosoftService.kt
+++ b/src/main/kotlin/com/kartverket/microsoft/MicrosoftService.kt
@@ -32,9 +32,6 @@ object MicrosoftService {
         return graphClient.groups().byGroupId(groupId).get().toTeamDTO()
     }
 
-    fun getUserEmail(userId: String): String {
-        return graphClient.users().byUserId(userId).get().mail
-    }
 }
 
 fun Group.toTeamDTO(): TeamDTO {

--- a/src/main/kotlin/com/kartverket/plugins/Auth.kt
+++ b/src/main/kotlin/com/kartverket/plugins/Auth.kt
@@ -1,6 +1,5 @@
 package com.kartverket.plugins
 import com.auth0.jwk.JwkProviderBuilder
-import com.kartverket.configuration.AppConfig
 import com.kartverket.functions.metadata.FunctionMetadataService
 import com.kartverket.microsoft.MicrosoftService
 import io.ktor.server.application.*
@@ -90,8 +89,8 @@ fun hasTeamAccess(userId: String, teamId: String): Boolean {
 }
 
 fun hasSuperUserAccess(userId: String): Boolean {
-    val superUserTeamId = AppConfig.superUser.teamId ?: return false
-    return hasTeamAccess(userId, superUserTeamId)
+    val superUserGroupId = System.getenv("SUPER_USER_GROUP_ID") ?: return false
+    return hasTeamAccess(userId, superUserGroupId)
 }
 
 fun ApplicationCall.hasSuperUserAccess(): Boolean {

--- a/src/main/kotlin/com/kartverket/plugins/Auth.kt
+++ b/src/main/kotlin/com/kartverket/plugins/Auth.kt
@@ -1,5 +1,6 @@
 package com.kartverket.plugins
 import com.auth0.jwk.JwkProviderBuilder
+import com.kartverket.configuration.AppConfig
 import com.kartverket.functions.metadata.FunctionMetadataService
 import com.kartverket.microsoft.MicrosoftService
 import io.ktor.server.application.*
@@ -89,8 +90,8 @@ fun hasTeamAccess(userId: String, teamId: String): Boolean {
 }
 
 fun hasSuperUserAccess(userId: String): Boolean {
-    val superUserEmail = System.getenv("SUPER_USER_EMAIL")
-    return MicrosoftService.getUserEmail(userId) == superUserEmail
+    val superUserTeamId = AppConfig.superUser.teamId ?: return false
+    return hasTeamAccess(userId, superUserTeamId)
 }
 
 fun ApplicationCall.hasSuperUserAccess(): Boolean {

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,0 +1,6 @@
+functionHistoryCleanup {
+  # How often cleanup runs in weeks
+  cleanupIntervalWeeks = 1,
+  # How old records to delete in days
+  deleteOlderThanDays = 30
+}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -4,3 +4,7 @@ functionHistoryCleanup {
   # How old records to delete in days
   deleteOlderThanDays = 30
 }
+
+superUser {
+    teamId = "4d6b2e80-2707-46bb-88de-b1186666d6ee"
+}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -4,7 +4,3 @@ functionHistoryCleanup {
   # How old records to delete in days
   deleteOlderThanDays = 30
 }
-
-superUser {
-    teamId = "4d6b2e80-2707-46bb-88de-b1186666d6ee"
-}


### PR DESCRIPTION
## Beskrivelse

🥅 Mål med PRen: Bedre adminstyrng i frisk

## Løsning

🆕 Endring: 
Put request er beskyttet slik at bruker må være en del av teamet som eier funksjonen eller være en superUser.
Superuser er et team i entra og hentes via en miljøvariabel `SUPER_USER_GROUP_ID` i `Auth.kt`.
Miljøvariabelen blir satt fra SKIP

Det samme gjelder Delete requests. I dev har alle superusertilgang mens i prod har SKVIS superusertilgang


