### PR TITLE
Flytte tilgangskontroll backend

### DIFF
--- a/src/main/kotlin/com/kartverket/functions/FunctionRoutes.kt
+++ b/src/main/kotlin/com/kartverket/functions/FunctionRoutes.kt
@@ -103,6 +103,17 @@ fun Route.functionRoutes() {
                 val children = FunctionService.getChildren(id)
                 call.respond(children)
             }
+            get("access") {
+                logger.info("Received get request on functions/{id}/access")
+                val id = call.parameters["id"]?.toInt() ?: run {
+                    logger.error("Invalid id parameter")
+                    call.respond(HttpStatusCode.BadRequest, "You have to supply an id")
+                    return@get
+                }
+
+                val hasAccess = call.hasFunctionAccess(id) || call.hasSuperUserAccess()
+                call.respond(hasAccess)
+            }
         }
     }
 }

--- a/src/main/kotlin/com/kartverket/functions/FunctionRoutes.kt
+++ b/src/main/kotlin/com/kartverket/functions/FunctionRoutes.kt
@@ -103,7 +103,7 @@ fun Route.functionRoutes() {
                 val children = FunctionService.getChildren(id)
                 call.respond(children)
             }
-            get("access") {
+            get("/access") {
                 logger.info("Received get request on functions/{id}/access")
                 val id = call.parameters["id"]?.toInt() ?: run {
                     logger.error("Invalid id parameter")

--- a/src/main/kotlin/com/kartverket/functions/metadata/FunctionMetadataRoutes.kt
+++ b/src/main/kotlin/com/kartverket/functions/metadata/FunctionMetadataRoutes.kt
@@ -40,7 +40,7 @@ fun Route.functionMetadataRoutes() {
                     FunctionMetadataService.addMetadataToFunction(id, metadata)
                     call.respond(HttpStatusCode.NoContent)
                 }
-                get("access") {
+                get("/access") {
                     val id = call.parameters["id"]?.toInt() ?: run {
                         call.respond(HttpStatusCode.BadRequest, "Invalid function id")
                         return@get

--- a/src/main/kotlin/com/kartverket/functions/metadata/FunctionMetadataRoutes.kt
+++ b/src/main/kotlin/com/kartverket/functions/metadata/FunctionMetadataRoutes.kt
@@ -2,6 +2,7 @@ package com.kartverket.functions.metadata
 
 import com.kartverket.plugins.hasFunctionAccess
 import com.kartverket.plugins.hasMetadataAccess
+import com.kartverket.plugins.hasSuperUserAccess
 import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.plugins.*
@@ -38,6 +39,15 @@ fun Route.functionMetadataRoutes() {
                     val metadata = call.receive<CreateFunctionMetadataDTO>()
                     FunctionMetadataService.addMetadataToFunction(id, metadata)
                     call.respond(HttpStatusCode.NoContent)
+                }
+                get("access") {
+                    val id = call.parameters["id"]?.toInt() ?: run {
+                        call.respond(HttpStatusCode.BadRequest, "Invalid function id")
+                        return@get
+                    }
+
+                    val hasAccess = call.hasFunctionAccess(id) || call.hasSuperUserAccess()
+                    call.respond(hasAccess)
                 }
             }
         }


### PR DESCRIPTION
**Beskrivelse**

🥅 Mål med PRen: med mål om å flytte tilgangskontroll til backenden - fordi da slipper man å oppdatere både backend og frontend når man vil oppdatere tilgangslogikken, i tillegg til at man ikke risikerer diff i tilgangskontrollen til backend vs frongtend. 

**Løsning**

🆕 Endring: 
Både metadata og function har fått hvert sitt endepunkt access som sjekker om bruker er på teamet som eier funksjonen eller superuser. Siden metadata og function har vært sitt gir dette støtte for å kunne håndtere tilgangslogikken her annerledes. 

**🧪 Testing**

sjekk om du får kalt endepunketen

🔒 **Sikkerhet / Trusselvurdering**

bedring av tilgangskontroll
