### PR TITLE
Modify gradle CI file

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -5,53 +5,131 @@
 # This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
 
-name: Java CI with Gradle
+name: Build, test and scan
 
 on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
 
 permissions:
   contents: read
 
+env:
+  REGISTRY: ghcr.io
+
 jobs:
-  build:
-
+  test:
+    name: Gradle tests
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres
-        ports:
-          - 5432:5432
-        env:
-          POSTGRES_DB: frisk-backend-db
-          POSTGRES_USER: postgres
-          POSTGRES_HOST_AUTH_METHOD: trust
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up JDK 17
-      uses: actions/setup-java@v4
-      with:
-        java-version: '17'
-        distribution: 'temurin'
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    
-    - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
-    - name: Build with Gradle Wrapper
-      run: ./gradlew build
-      env:
-        environment: test
-    - name: Test with Gradle
-      run: ./gradlew test
-      env:
-        environment: test
-      
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          architecture: 'x64'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Build with Gradle Wrapper
+        run: ./gradlew build
+        env:
+          environment: test
+
+      - name: Test with Gradle
+        run: ./gradlew test
+        env:
+          environment: test
+
+  docker:
+    name: Build and push docker image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    outputs:
+      image_url: ${{ steps.setOutput.outputs.image_url }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          architecture: 'x64'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Execute Gradle build
+        run: ./gradlew shadowJar
+
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}
+          tags: |
+            type=sha,format=long
+            type=raw,value=${{ github.sha }}
+
+      - name: Build docker and push
+        id: build-docker
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: DockerfileForSkip
+          push: ${{ !github.event.pull_request.draft }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Set output with build values
+        id: setOutput
+        run: |
+          echo "image_url=${{ env.REGISTRY }}/${{ github.repository }}@${{ steps.build-docker.outputs.digest }}" >> $GITHUB_OUTPUT
+
+  dependencygraph:
+    name: Generate dependency graph
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          architecture: 'x64'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@v3
+
+  pharos:
+    name: Run Pharos
+    needs: docker
+    permissions:
+      actions: read
+      packages: read
+      contents: read
+      security-events: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Run Pharos"
+        uses: kartverket/pharos@v0.2.2
+        with:
+          image_url: ${{ needs.docker.outputs.image_url }}


### PR DESCRIPTION
**Beskrivelse**

🥅 Mål med PRen: Kontinuerlig scanning og testing av applikasjonen

**Løsning**

🆕 Endring: Justerer gradle-workflow til å alltid kjøre ved PR. Legger også til bygg av docker image, og scanning av image med Pharos. Dermed vil vi få tidlig feedback om tester skulle knekke eller sårbarhet i avhengigheter oppdages.

**🧪 Testing**


🔒 **Sikkerhet / Trusselvurdering**

- Er det potensielle risikoer knyttet til endringen?
- Trengs det noen sikkerhetstiltak eller ytterligere vurderinger?
