### PR TITLE
Skru på testene i FunctionRoutesTest

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,10 @@ plugins {
 group = "com.kartverket"
 version = "0.0.1"
 
+kotlin {
+    jvmToolchain(21)
+}
+
 application {
     mainClass.set("com.kartverket.ApplicationKt")
 
@@ -53,12 +57,11 @@ dependencies {
     implementation("io.ktor:ktor-client-cio-jvm:2.3.12")
     testImplementation("io.ktor:ktor-server-test-host-jvm")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version")
-    testImplementation("org.jetbrains.kotlin:kotlin-test:$kotlin_version")
     testImplementation("io.ktor:ktor-server-test-host")
     testImplementation("io.mockk:mockk:1.13.16")
-    testImplementation("org.testcontainers:testcontainers:1.20.4")
+    testImplementation("org.testcontainers:testcontainers:1.20.5")
     testImplementation("org.apache.commons:commons-compress:1.26.0")
-    testImplementation("org.testcontainers:postgresql:1.20.4")
+    testImplementation("org.testcontainers:postgresql:1.20.5")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.11.4")
 }
 
@@ -81,5 +84,6 @@ tasks {
             exceptionFormat = TestExceptionFormat.FULL
             events("passed", "skipped", "failed")
         }
+        useJUnitPlatform()
     }
 }

--- a/src/test/kotlin/com/kartverket/TestUtils.kt
+++ b/src/test/kotlin/com/kartverket/TestUtils.kt
@@ -26,14 +26,13 @@ import java.util.*
 import kotlin.test.assertEquals
 
 object TestUtils {
-
+/*
     private var isDatabaseInitialized = false
     val postgresContainer = PostgreSQLContainer("postgres:15-alpine").apply {
         start()
-    }
+    }*/
 
     fun Application.testModule() {
-        setupTestDatabase()
         configureSerialization()
 
         install(Authentication) {
@@ -60,7 +59,7 @@ object TestUtils {
             .sign(Algorithm.HMAC256("test-secret"))
     }
 
-    private fun setupTestDatabase() {
+/*    private fun setupTestDatabase() {
         if (isDatabaseInitialized) return
         isDatabaseInitialized = true
 
@@ -83,7 +82,7 @@ object TestUtils {
 
     fun stopTestDatabase() {
         postgresContainer.stop()
-    }
+    }*/
 
     suspend fun createFunction(client: HttpClient, parentId: Int): Function {
         val function = CreateFunctionDto(

--- a/src/test/kotlin/com/kartverket/functions/metadata/FunctionMetadataRoutesTest.kt
+++ b/src/test/kotlin/com/kartverket/functions/metadata/FunctionMetadataRoutesTest.kt
@@ -4,7 +4,6 @@ import com.kartverket.TestUtils
 import com.kartverket.TestUtils.addMetadata
 import com.kartverket.TestUtils.createFunction
 import com.kartverket.TestUtils.generateTestToken
-import com.kartverket.TestUtils.postgresContainer
 import com.kartverket.TestUtils.testModule
 import com.kartverket.functions.Function
 import com.kartverket.plugins.hasFunctionAccess
@@ -21,26 +20,11 @@ import io.mockk.verify
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.junit.Test
-import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.BeforeAll
 import java.util.*
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class FunctionMetadataRoutesTest {
-    companion object {
-        @BeforeAll
-        @JvmStatic
-        fun setup() {
-            postgresContainer.start()
-        }
-
-        @AfterAll
-        @JvmStatic
-        fun teardown() {
-            TestUtils.stopTestDatabase()
-        }
-    }
 
     @Test
     fun testGetFunctionMetadata() = testApplication {


### PR DESCRIPTION
**Beskrivelse**

🥅 Mål med PRen: Få testene i FunctionRoutesTest til å kjøre

**Løsning**

🆕 Endring: Skrudde på junitPlatform og la til nødvendige mocks av Singletons for at testene skulle kjøre. Testene er nå isolert til FunctionRoutes, slik at de kun tester api-laget.

Har skrudd av enkelte tester, enten fordi de testet lignende funksjonalitet som andre tester, eller fordi de testet funksjonalitet lenger ned i koden. La merke til at flere av testene kan brukes for integrasjonstest, og mulig flere av dem blir det, men nå var fokuset å få testene til å kjøre.

🔒 **Sikkerhet / Trusselvurdering**

- Er det potensielle risikoer knyttet til endringen?
- Trengs det noen sikkerhetstiltak eller ytterligere vurderinger?
