### PR TITLE
Legge til dependabot for oppdatering av avhengigheter

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "gradle" 
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions" 
+    directory: ".github/workflows"
+    schedule:
+      interval: "weekly"
+
+


### PR DESCRIPTION
**Beskrivelse**

🥅 Legge til dependabot config slik at vi får vanlige oppdateringer i tillegg til sikkerhetsoppdateringer.

**Løsning**

🆕 Legger til dependabot.yml slik at både Gradle avhengigheter og Github Actions blir sjekket for oppdateringer ukentlig.

**🧪 Testing**

*Er det noe spesielt den som reviewer PRen bør sjekke?*

🔒 **Sikkerhet / Trusselvurdering**

- Er det potensielle risikoer knyttet til endringen?
- Trengs det noen sikkerhetstiltak eller ytterligere vurderinger?
