### PR TITLE
Add integration test for FunctionMetadata

### DIFF
--- a/src/test/kotlin/com/kartverket/integrationTests/FunctionMetadataIntegrationTest.kt
+++ b/src/test/kotlin/com/kartverket/integrationTests/FunctionMetadataIntegrationTest.kt
@@ -1,0 +1,130 @@
+package com.kartverket.integrationTests
+
+import com.kartverket.TestDatabase
+import com.kartverket.TestUtils.generateTestToken
+import com.kartverket.TestUtils.testModule
+import com.kartverket.functions.CreateFunctionDto
+import com.kartverket.functions.CreateFunctionWithMetadataDto
+import com.kartverket.functions.Function
+import com.kartverket.functions.metadata.CreateFunctionMetadataDTO
+import com.kartverket.functions.metadata.FunctionMetadata
+import com.kartverket.functions.metadata.UpdateFunctionMetadataDTO
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.server.testing.*
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import java.util.*
+
+class FunctionMetadataIntegrationTest {
+
+    @Test
+    fun `Create, read, update and delete function metadata`() = testApplication {
+        application {
+            testModule()
+        }
+        val database = TestDatabase()
+        database.setupTestDatabase()
+
+        val functionName = "${UUID.randomUUID()}"
+
+        val createFunctionDto = CreateFunctionDto(
+            name = functionName, description = "desc", parentId = 1
+        )
+
+        var response = client.post("/functions") {
+            header(HttpHeaders.Authorization, "Bearer ${generateTestToken()}")
+            contentType(ContentType.Application.Json)
+            setBody(
+                Json.encodeToString(
+                    CreateFunctionWithMetadataDto(
+                        function = createFunctionDto, metadata = emptyList()
+                    )
+                )
+            )
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+
+        val function: Function = Json.decodeFromString(response.bodyAsText())
+
+        // Create meatadata for function
+        val createFunctionMetadataDTO = CreateFunctionMetadataDTO(key = "${UUID.randomUUID()}", value = "value")
+        response = client.post("/functions/${function.id}/metadata") {
+            header(HttpHeaders.Authorization, "Bearer ${generateTestToken()}")
+            contentType(ContentType.Application.Json)
+            setBody(Json.encodeToString(createFunctionMetadataDTO))
+        }
+        assertEquals(HttpStatusCode.NoContent, response.status)
+
+        // Get metadata to verify fields
+        val metadata = client.get("/functions/${function.id}/metadata") {
+            header(HttpHeaders.Authorization, "Bearer ${generateTestToken()}")
+        }
+        val metadataList: List<FunctionMetadata> = Json.decodeFromString(metadata.bodyAsText())
+
+        assertEquals(metadataList.size, 1)
+        metadataList.first().let {
+            assertEquals(function.id, it.functionId)
+            assertEquals(createFunctionMetadataDTO.key, it.key)
+            assertEquals(createFunctionMetadataDTO.value, it.value)
+        }
+
+        // Update metadata
+        val newMetadataValue = "New value"
+        val request = UpdateFunctionMetadataDTO(newMetadataValue)
+
+        response = client.patch("/metadata/${metadataList.first().id}") {
+            header(HttpHeaders.Authorization, "Bearer ${generateTestToken()}")
+            contentType(ContentType.Application.Json)
+            setBody(Json.encodeToString(request))
+        }
+        assertEquals(HttpStatusCode.NoContent, response.status)
+
+        // Get updated metadata to verify that the value is updated
+        val updatedMetadata = client.get("/functions/${function.id}/metadata") {
+            header(HttpHeaders.Authorization, "Bearer ${generateTestToken()}")
+        }
+        val updatedMetadataList: List<FunctionMetadata> = Json.decodeFromString(updatedMetadata.bodyAsText())
+        assertEquals(metadataList.size, 1)
+        assertEquals(newMetadataValue, updatedMetadataList.first().value)
+
+        // Delete metadata
+        response = client.delete("/metadata/${metadataList.first().id}") {
+            header(HttpHeaders.Authorization, "Bearer ${generateTestToken()}")
+        }
+        assertEquals(HttpStatusCode.NoContent, response.status)
+
+        //Try to get deleted metadata to verify that it's deleted
+        val deletedMetadata = client.get("/functions/${function.id}/metadata") {
+            header(HttpHeaders.Authorization, "Bearer ${generateTestToken()}")
+        }
+        Json.decodeFromString<List<FunctionMetadata>>(deletedMetadata.bodyAsText()).let {
+            assertTrue(it.isEmpty())
+        }
+    }
+
+    companion object {
+
+        private lateinit var database: TestDatabase
+
+        @JvmStatic
+        @BeforeAll
+        fun setup() {
+            database = TestDatabase()
+            database.setupTestDatabase()
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun cleanup() {
+            database.stopTestDatabase()
+        }
+    }
+}

--- a/src/test/kotlin/com/kartverket/integrationTests/FunctionRoutesIntegrationTest.kt
+++ b/src/test/kotlin/com/kartverket/integrationTests/FunctionRoutesIntegrationTest.kt
@@ -115,14 +115,14 @@ class FunctionRoutesIntegrationTest {
 
         @JvmStatic
         @BeforeAll
-        fun setup(): Unit {
+        fun setup() {
             database = TestDatabase()
             database.setupTestDatabase()
         }
 
         @JvmStatic
         @AfterAll
-        fun cleanup(): Unit {
+        fun cleanup() {
             database.stopTestDatabase()
         }
     }


### PR DESCRIPTION
**Beskrivelse**

🥅 Mål med PRen: Smoketest for å dekke diverse funksjonalitet i applikasjonen før videre refaktorering.

Løsning

🆕 Endring: La til disse for å dekke flere lag av applikasjonen, utover de testene som allerede er lagt inn for api-laget. Burde strengt tatt ha egne tester for databaselaget også, men det kan komme senere i forbindelse med refaktorering til injection istedenfor singleton.

**🧪 Testing**

*Er det noe spesielt den som reviewer PRen bør sjekke?*

🔒 **Sikkerhet / Trusselvurdering**

- Er det potensielle risikoer knyttet til endringen?
- Trengs det noen sikkerhetstiltak eller ytterligere vurderinger?
