### PR TITLE
Extract database config to AppConfig

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,1 @@
+ALLOWED_CORS_HOSTS = "localhost:5173,localhost:5177"

--- a/src/main/kotlin/com/kartverket/Application.kt
+++ b/src/main/kotlin/com/kartverket/Application.kt
@@ -58,7 +58,7 @@ fun cleanupFunctionsHistory(deleteOlderThanDays: Int) {
 
 fun Application.module() {
     val config = AppConfig.load(environment.config)
-    Database.initDatabase()
+    Database.initDatabase(config.databaseConfig)
     Database.migrate()
     configureAPILayer(config)
     launchCleanupJob(config.functionHistoryCleanup)

--- a/src/main/kotlin/com/kartverket/configuration/AppConfig.kt
+++ b/src/main/kotlin/com/kartverket/configuration/AppConfig.kt
@@ -1,21 +1,32 @@
 package com.kartverket.configuration
 
 import io.ktor.server.config.*
+import org.slf4j.LoggerFactory
+import java.net.URI
 
-class AppConfig(
+data class AppConfig(
     val functionHistoryCleanup: FunctionHistoryCleanupConfig,
-    val allowedCORSHosts: List<String>
+    val allowedCORSHosts: List<String>,
+    val databaseConfig: DatabaseConfig
 ) {
+
+
 
     companion object {
         fun load(config: ApplicationConfig): AppConfig {
             val allowedCORSHosts = System.getenv("ALLOWED_CORS_HOSTS").split(",")
+
             return AppConfig(
                 functionHistoryCleanup = FunctionHistoryCleanupConfig(
-                    cleanupIntervalWeeks = config.propertyOrNull("functionHistoryCleanup.cleanupIntervalWeeks")?.getString()?.toInt() ?: throw IllegalStateException("Unable to initialize app config \"functionHistoryCleanup.cleanupIntervalWeeks\""),
-                    deleteOlderThanDays = config.propertyOrNull("functionHistoryCleanup.deleteOlderThanDays")?.getString()?.toInt() ?: throw IllegalStateException("Unable to initialize app config \"functionHistoryCleanup.deleteOlderThanDays\""),
+                    cleanupIntervalWeeks = config.propertyOrNull("functionHistoryCleanup.cleanupIntervalWeeks")
+                        ?.getString()?.toInt()
+                        ?: throw IllegalStateException("Unable to initialize app config \"functionHistoryCleanup.cleanupIntervalWeeks\""),
+                    deleteOlderThanDays = config.propertyOrNull("functionHistoryCleanup.deleteOlderThanDays")
+                        ?.getString()?.toInt()
+                        ?: throw IllegalStateException("Unable to initialize app config \"functionHistoryCleanup.deleteOlderThanDays\""),
                 ),
-                allowedCORSHosts = allowedCORSHosts
+                allowedCORSHosts = allowedCORSHosts,
+                databaseConfig = DatabaseConfig.load()
             )
         }
     }
@@ -26,3 +37,58 @@ data class FunctionHistoryCleanupConfig(
     val cleanupIntervalWeeks: Int,
     val deleteOlderThanDays: Int
 )
+
+class DatabaseConfig(
+    val jdbcUrl: String,
+    val username: String,
+    val password: String,
+) {
+    companion object {
+        private val logger = LoggerFactory.getLogger(DatabaseConfig::class.java)
+
+        fun load(): DatabaseConfig {
+            val env = System.getenv("environment")
+            return if (env == "production") {
+                val platform = System.getenv("platform")
+                if (platform == "flyio") {
+                    logger.info("Using Fly.io database configuration")
+                    System.getenv("DATABASE_URL").let { databaseUrl ->
+                        val dbUri = URI(databaseUrl)
+                        val (user, pass) = dbUri.userInfo.split(":", limit = 2)
+                        DatabaseConfig(
+                            jdbcUrl = "jdbc:postgresql://${dbUri.host}:${dbUri.port}${dbUri.path}?sslmode=disable",
+                            username = user,
+                            password = pass,
+                        )
+                    }
+                } else {
+                    logger.info("Using gcp database configuration")
+                    val serverCertPath = "/app/db-ssl-ca/server-ca.pem"
+                    val clientCertPath = "/app/db-ssl-ca/client-cert.pem"
+                    val clientKeyPath = "/app/db-ssl-ca/client-key.pk8"
+
+                    DatabaseConfig(
+                        jdbcUrl = "jdbc:postgresql://${
+                            System.getenv(
+                                "DATABASE_HOST",
+                            )
+                        }:5432/frisk-backend-db?sslmode=require&sslrootcert=$serverCertPath$&sslcert=$clientCertPath&sslkey=$clientKeyPath",
+                        username = "admin",
+                        password = System.getenv("DATABASE_PASSWORD") ?: ""
+                    )
+                }
+            } else {
+                logger.info("Using local development database configuration")
+                val jdbcUrl = "jdbc:postgresql://localhost:5432/frisk-backend-db"
+                val username = "postgres"
+                val password = ""
+
+                DatabaseConfig(
+                    jdbcUrl = jdbcUrl,
+                    username = username,
+                    password = password
+                )
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/kartverket/ApplicationTest.kt
+++ b/src/test/kotlin/com/kartverket/ApplicationTest.kt
@@ -1,4 +1,5 @@
 import com.kartverket.configuration.AppConfig
+import com.kartverket.configuration.DatabaseConfig
 import com.kartverket.configuration.FunctionHistoryCleanupConfig
 import com.kartverket.configureAPILayer
 import io.ktor.client.request.*
@@ -11,10 +12,12 @@ import org.junit.jupiter.api.assertAll
 import org.junit.jupiter.api.fail
 
 class ApplicationTest {
+    private val exampleConfig = AppConfig(FunctionHistoryCleanupConfig(1, 1), emptyList(), DatabaseConfig("", "", ""))
+
     @Test
     fun `Verify that authentication is enabled on non-public endpoints`() = testApplication {
         application {
-            configureAPILayer(AppConfig(FunctionHistoryCleanupConfig(1, 1), emptyList()))
+            configureAPILayer(exampleConfig)
             routing {
                 val publicEndpointsRegexList = listOf(
                     Regex("^/swagger"),
@@ -54,7 +57,11 @@ class ApplicationTest {
     @Test
     fun `Verify that CORS is enabled`() = testApplication {
         application {
-            configureAPILayer(AppConfig(FunctionHistoryCleanupConfig(1, 1), listOf("test.com")))
+            configureAPILayer(
+                exampleConfig.copy(
+                    allowedCORSHosts = listOf("test.com")
+                )
+            )
         }
 
         val failedCors = client.get("/health") {


### PR DESCRIPTION
**Beskrivelse**

🥅 Mål med PRen: Flytt databaseconfig til config-klassen.

**Løsning**

🆕 Endring: This is a preparation for two things:
- Make all configuration environment based
- Refactor Database from object to class

Incidentally, we could also remove some duplication, as the database config code was duplicated between the initDatabase and migrate functions. migrate now relies on the same datasource as normal database usage.

So endgoal is that the full jdbc-url, username and password are fetched from config/environment variables, and not partially hardcoded.

**🧪 Testing**

*Er det noe spesielt den som reviewer PRen bør sjekke?*

🔒 **Sikkerhet / Trusselvurdering**

- Er det potensielle risikoer knyttet til endringen?
- Trengs det noen sikkerhetstiltak eller ytterligere vurderinger?
