### PR TITLE
Fix history cleanup SQL

### DIFF
--- a/src/main/kotlin/com/kartverket/Application.kt
+++ b/src/main/kotlin/com/kartverket/Application.kt
@@ -47,7 +47,7 @@ fun cleanupFunctionsHistory(deleteOlderThanDays: Int) {
     logger.info("Running scheduled cleanup for functions_history table. Deleting entries older than $deleteOlderThanDays days.")
 
     Database.getConnection().use { conn ->
-        conn.prepareStatement("DELETE FROM functions_history WHERE valid_from < NOW() - INTERVAL '? days'")
+        conn.prepareStatement("DELETE FROM functions_history WHERE valid_from < NOW() - make_interval(days := ?)")
             .use { stmt ->
                 stmt.setInt(1, deleteOlderThanDays)
                 val deletedRows = stmt.executeUpdate()

--- a/src/main/kotlin/com/kartverket/Database.kt
+++ b/src/main/kotlin/com/kartverket/Database.kt
@@ -14,17 +14,22 @@ object Database {
     private val logger = KtorSimpleLogger("Database")
 
     fun getDump(): List<DumpRow> {
-        val query = "select * from functions f inner join function_metadata fm on fm.function_id = f.id inner join function_metadata_keys fmk on fmk.id = fm.key_id"
-        val dump = mutableListOf<DumpRow>()
+        val query =
+            """
+    select * from functions f
+    inner join function_metadata fm on fm.function_id = f.id
+    inner join function_metadata_keys fmk on fmk.id = fm.key_id
+""".trimIndent()
         getConnection().use { connection ->
             connection.prepareStatement(query).use { preparedStatement ->
                 val resultSet = preparedStatement.executeQuery()
-                while (resultSet.next()) {
-                    dump.add(resultSet.toDumpRow())
+                return buildList {
+                    while (resultSet.next()) {
+                        add(resultSet.toDumpRow())
+                    }
                 }
             }
         }
-        return dump
     }
 
     fun initDatabase(databaseConfig: DatabaseConfig) {


### PR DESCRIPTION
**Beskrivelse**

🥅 Mål med PRen: My bad! Fikse en bug introdusert av at jeg ville få inn statement parameter istedenfor string templating i cleanup history SQL'n.

**Løsning**

🆕 Endring: We introduced a bug that broke the cleanup function. 'INTERVAL X DAYS' is a literal in SQL, so trying to inject the number of days via statement parameters did not work. Fixed it by using the make_interval function available in Postgres.

Also refactored the dump function to remove the mutable list.

**🧪 Testing**

*Er det noe spesielt den som reviewer PRen bør sjekke?*

🔒 **Sikkerhet / Trusselvurdering**

- Er det potensielle risikoer knyttet til endringen?
- Trengs det noen sikkerhetstiltak eller ytterligere vurderinger?
