### PR TITLE
Refactor database from singleton into injected dependency

### DIFF
--- a/src/main/kotlin/com/kartverket/functions/FunctionService.kt
+++ b/src/main/kotlin/com/kartverket/functions/FunctionService.kt
@@ -41,6 +41,7 @@ data class UpdateFunctionDto(
 )
 
 object FunctionService {
+    lateinit var database: Database
     val logger = KtorSimpleLogger("FunctionService")
 
     fun getFunctions(search: String? = null): List<Function> {
@@ -53,7 +54,7 @@ object FunctionService {
             query = "SELECT * FROM functions"
         }
 
-        Database.getConnection().use { connection ->
+        database.getConnection().use { connection ->
             logger.debug("Preparing database query: $query")
             connection.prepareStatement(query).use { statement ->
                 if (search != null) {
@@ -72,7 +73,7 @@ object FunctionService {
         logger.info("Getting function with id: $id")
         val query = "SELECT * FROM functions where id = ?"
         logger.debug("Preparing database query: $query")
-        Database.getConnection().use { connection ->
+        database.getConnection().use { connection ->
             connection.prepareStatement(query).use { statement ->
                 statement.setInt(1, id)
                 val resultSet = statement.executeQuery()
@@ -89,7 +90,7 @@ object FunctionService {
         val functions = mutableListOf<Function>()
         val query = "SELECT * FROM functions WHERE parent_id = ? ORDER BY order_index"
         logger.debug("Preparing database query: $query")
-        Database.getConnection().use { connection ->
+        database.getConnection().use { connection ->
             connection.prepareStatement(query).use { statement ->
                 statement.setInt(1, id)
                 val resultSet = statement.executeQuery()
@@ -105,7 +106,7 @@ object FunctionService {
         logger.info("Creating function with: ${newFunction.name}")
         val query = "INSERT INTO functions (name, description, parent_id) VALUES (?, ?, ?) RETURNING *"
         logger.debug("Preparing database query: $query")
-        Database.getConnection().use { connection ->
+        database.getConnection().use { connection ->
             connection.prepareStatement(query).use { statement ->
                 statement.setString(1, newFunction.name)
                 statement.setString(2, newFunction.description)
@@ -128,7 +129,7 @@ object FunctionService {
 
         val query = "SELECT * FROM update_function(?, ?, ?, ?, ?);"
         logger.debug("Preparing database query: $query")
-        Database.getConnection().use { connection ->
+        database.getConnection().use { connection ->
 
             connection.prepareStatement(query).use { statement ->
                 var i = 1
@@ -156,7 +157,7 @@ object FunctionService {
         logger.info("Deleting function with id: $id")
         val query = "DELETE FROM functions WHERE id = ?"
         logger.debug("Preparing database query: $query")
-        Database.getConnection().use { connection ->
+        database.getConnection().use { connection ->
             connection.prepareStatement(query).use { statement ->
                 statement.setInt(1, id)
                 return statement.executeUpdate() > 0

--- a/src/main/kotlin/com/kartverket/plugins/Routing.kt
+++ b/src/main/kotlin/com/kartverket/plugins/Routing.kt
@@ -1,10 +1,10 @@
 package com.kartverket.plugins
 
+import com.kartverket.DumpRow
 import com.kartverket.Database
 import com.kartverket.functions.functionRoutes
 import com.kartverket.functions.metadata.functionMetadataRoutes
 import com.kartverket.microsoft.microsoftRoutes
-import com.kartverket.toCsv
 import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.auth.*
@@ -12,7 +12,7 @@ import io.ktor.server.routing.*
 import io.ktor.server.plugins.swagger.*
 import io.ktor.server.response.*
 
-fun Application.configureRouting() {
+fun Application.configureRouting(database: Database) {
     routing {
         swaggerUI(path = "swagger", swaggerFile = "openapi/documentation.yaml")
         authenticate(AUTH_JWT, strategy = AuthenticationStrategy.Required) {
@@ -31,7 +31,7 @@ fun Application.configureRouting() {
                 )
 
                 call.respondBytes(
-                    bytes = Database.getDump().toCsv().toByteArray(Charsets.UTF_8),
+                    bytes = database.getDump().toCsv().toByteArray(Charsets.UTF_8),
                     contentType = ContentType.Text.CSV.withCharset(Charsets.UTF_8)
                 )
             }
@@ -40,6 +40,15 @@ fun Application.configureRouting() {
             get {
                 call.respondText("Up and running!", ContentType.Text.Plain)
             }
+        }
+    }
+}
+
+fun List<DumpRow>.toCsv(): String {
+    return buildString {
+        appendLine("id,name,description,path,key,value")
+        for (row in this@toCsv) {
+            appendLine("\"${row.id}\",\"${row.name}\",\"${row.description}\",\"${row.path}\",\"${row.key}\",\"${row.value}\"")
         }
     }
 }

--- a/src/test/kotlin/com/kartverket/ApplicationTest.kt
+++ b/src/test/kotlin/com/kartverket/ApplicationTest.kt
@@ -1,3 +1,5 @@
+import com.kartverket.DumpRow
+import com.kartverket.Database
 import com.kartverket.configuration.AppConfig
 import com.kartverket.configuration.DatabaseConfig
 import com.kartverket.configuration.FunctionHistoryCleanupConfig
@@ -10,14 +12,25 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
 import org.junit.jupiter.api.fail
+import java.sql.Connection
 
 class ApplicationTest {
     private val exampleConfig = AppConfig(FunctionHistoryCleanupConfig(1, 1), emptyList(), DatabaseConfig("", "", ""))
+    private val mockDatabase = object : Database {
+        override fun getDump(): List<DumpRow> {
+            TODO("Not yet implemented")
+        }
+
+        override fun getConnection(): Connection {
+            TODO("Not yet implemented")
+        }
+
+    }
 
     @Test
     fun `Verify that authentication is enabled on non-public endpoints`() = testApplication {
         application {
-            configureAPILayer(exampleConfig)
+            configureAPILayer(exampleConfig, mockDatabase)
             routing {
                 val publicEndpointsRegexList = listOf(
                     Regex("^/swagger"),
@@ -60,7 +73,8 @@ class ApplicationTest {
             configureAPILayer(
                 exampleConfig.copy(
                     allowedCORSHosts = listOf("test.com")
-                )
+                ),
+                mockDatabase
             )
         }
 

--- a/src/test/kotlin/com/kartverket/TestDatabase.kt
+++ b/src/test/kotlin/com/kartverket/TestDatabase.kt
@@ -1,40 +1,26 @@
 package com.kartverket
 
+import com.kartverket.configuration.DatabaseConfig
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import org.flywaydb.core.Flyway
 import org.testcontainers.containers.PostgreSQLContainer
 
 class TestDatabase {
-    private var isDatabaseInitialized = false
     private val postgresContainer = PostgreSQLContainer("postgres:15-alpine").apply {
         start()
     }
+    lateinit var dataSource: HikariDataSource
 
-    fun setupTestDatabase() {
-        if (isDatabaseInitialized) return
-        isDatabaseInitialized = true
-
-        val hikariConfig = HikariConfig().apply {
-            jdbcUrl = postgresContainer.jdbcUrl
-            username = postgresContainer.username
-            password = postgresContainer.password
-            driverClassName = "org.postgresql.Driver"
-        }
-
-        Database.dataSource = HikariDataSource(hikariConfig)
-        val flyway = Flyway.configure()
-            .validateMigrationNaming(true)
-            .createSchemas(true)
-            .dataSource(Database.dataSource)
-            .locations("classpath:db/migration")
-            .load()
-
-        flyway.migrate()
+    fun getTestdatabaseConfig(): DatabaseConfig {
+        return DatabaseConfig(
+            jdbcUrl = postgresContainer.jdbcUrl,
+            username = postgresContainer.username,
+            password = postgresContainer.password,
+        )
     }
 
     fun stopTestDatabase() {
-        Database.closePool()
         postgresContainer.stop()
     }
 }

--- a/src/test/kotlin/com/kartverket/TestUtils.kt
+++ b/src/test/kotlin/com/kartverket/TestUtils.kt
@@ -5,7 +5,9 @@ import com.auth0.jwt.algorithms.Algorithm
 import com.kartverket.functions.CreateFunctionDto
 import com.kartverket.functions.CreateFunctionWithMetadataDto
 import com.kartverket.functions.Function
+import com.kartverket.functions.FunctionService
 import com.kartverket.functions.metadata.CreateFunctionMetadataDTO
+import com.kartverket.functions.metadata.FunctionMetadataService
 import com.kartverket.plugins.AUTH_JWT
 import com.kartverket.plugins.configureRouting
 import com.kartverket.plugins.configureSerialization
@@ -18,11 +20,22 @@ import io.ktor.server.auth.*
 import io.ktor.server.auth.jwt.*
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import java.sql.Connection
 import java.util.*
 import kotlin.test.assertEquals
 
 object TestUtils {
-    fun Application.testModule() {
+    private val mockDatabase: Database = object : Database {
+        override fun getDump(): List<DumpRow> {
+            TODO("Not yet implemented")
+        }
+
+        override fun getConnection(): Connection {
+            TODO("Not yet implemented")
+        }
+
+    }
+    fun Application.testModule(testDatabase: Database = mockDatabase) {
         configureSerialization()
 
         install(Authentication) {
@@ -38,7 +51,9 @@ object TestUtils {
                 validate { credentials -> JWTPrincipal(credentials.payload) }
             }
         }
-        configureRouting()
+        configureRouting(testDatabase)
+        FunctionService.database = testDatabase
+        FunctionMetadataService.database = testDatabase
     }
 
     fun generateTestToken(): String {

--- a/src/test/kotlin/com/kartverket/functions/FunctionRoutesTest.kt
+++ b/src/test/kotlin/com/kartverket/functions/FunctionRoutesTest.kt
@@ -86,7 +86,6 @@ class FunctionRoutesTest {
                 assertEquals(uniqueName, createdFunction.name)
 
                 verify { FunctionMetadataService.addMetadataToFunction(createdFunction.id, metadata) }
-                confirmVerified(FunctionMetadataService)
             }
         }
     }
@@ -202,7 +201,6 @@ class FunctionRoutesTest {
             assertEquals(1, fetchedFunction.orderIndex)
 
             verify { FunctionService.getFunction(functionId) }
-            confirmVerified(FunctionService)
         }
     }
 
@@ -235,7 +233,6 @@ class FunctionRoutesTest {
             assertEquals(HttpStatusCode.NotFound, response.status)
 
             verify { FunctionService.getFunction(functionId) }
-            confirmVerified(FunctionService)
         }
     }
 
@@ -376,7 +373,6 @@ class FunctionRoutesTest {
 
                 assertEquals(HttpStatusCode.NoContent, response.status)
                 verify { FunctionService.deleteFunction(1) }
-                confirmVerified(FunctionService)
             }
         }
     }
@@ -480,7 +476,6 @@ class FunctionRoutesTest {
             assertTrue(childrenFunctions.isEmpty())
 
             verify { FunctionService.getChildren(1) }
-            confirmVerified(FunctionService)
         }
     }
 }

--- a/src/test/kotlin/com/kartverket/integrationTests/FunctionMetadataIntegrationTest.kt
+++ b/src/test/kotlin/com/kartverket/integrationTests/FunctionMetadataIntegrationTest.kt
@@ -1,5 +1,6 @@
 package com.kartverket.integrationTests
 
+import com.kartverket.JDBCDatabase
 import com.kartverket.TestDatabase
 import com.kartverket.TestUtils.generateTestToken
 import com.kartverket.TestUtils.testModule
@@ -26,11 +27,10 @@ class FunctionMetadataIntegrationTest {
 
     @Test
     fun `Create, read, update and delete function metadata`() = testApplication {
+        val database = JDBCDatabase.create(testDatabase.getTestdatabaseConfig())
         application {
-            testModule()
+            testModule(database)
         }
-        val database = TestDatabase()
-        database.setupTestDatabase()
 
         val functionName = "${UUID.randomUUID()}"
 
@@ -112,19 +112,18 @@ class FunctionMetadataIntegrationTest {
 
     companion object {
 
-        private lateinit var database: TestDatabase
+        private lateinit var testDatabase: TestDatabase
 
         @JvmStatic
         @BeforeAll
         fun setup() {
-            database = TestDatabase()
-            database.setupTestDatabase()
+            testDatabase = TestDatabase()
         }
 
         @JvmStatic
         @AfterAll
         fun cleanup() {
-            database.stopTestDatabase()
+            testDatabase.stopTestDatabase()
         }
     }
 }

--- a/src/test/kotlin/com/kartverket/integrationTests/FunctionRoutesIntegrationTest.kt
+++ b/src/test/kotlin/com/kartverket/integrationTests/FunctionRoutesIntegrationTest.kt
@@ -1,5 +1,6 @@
 package com.kartverket.integrationTests
 
+import com.kartverket.JDBCDatabase
 import com.kartverket.TestDatabase
 import com.kartverket.TestUtils.generateTestToken
 import com.kartverket.TestUtils.testModule
@@ -23,11 +24,10 @@ class FunctionRoutesIntegrationTest {
 
     @Test
     fun `Create, read, update and delete function`() = testApplication {
+        val database = JDBCDatabase.create(testDatabase.getTestdatabaseConfig())
         application {
-            testModule()
+            testModule(database)
         }
-        val database = TestDatabase()
-        database.setupTestDatabase()
 
         val functionName = "${UUID.randomUUID()}"
 
@@ -111,19 +111,18 @@ class FunctionRoutesIntegrationTest {
 
     companion object {
 
-        private lateinit var database: TestDatabase
+        private lateinit var testDatabase: TestDatabase
 
         @JvmStatic
         @BeforeAll
         fun setup() {
-            database = TestDatabase()
-            database.setupTestDatabase()
+            testDatabase = TestDatabase()
         }
 
         @JvmStatic
         @AfterAll
         fun cleanup() {
-            database.stopTestDatabase()
+            testDatabase.stopTestDatabase()
         }
     }
 }


### PR DESCRIPTION
**Beskrivelse**

🥅 Mål med PRen: Forenkle testing av koden ved å gå bort fra Singleton

**Løsning**

🆕 Endring: Endrer Database til å være en klasse som opprettes, og injectes der den trengs. Dermed løsnes den tette koblingen mellom Database singleton og kallstedene.

Flyttet også kallet til migrate inn i create-metoden til JDCBDatabase, da applikasjonen ikke fungerer uten en database med korrekte skjema. At databasen har korrekt skjema er også strengt tatt noe den spesifikke database-klassen bryr seg om, ikke noen andre deler av applikasjonen 😊 

**🧪 Testing**

Fjernet confirmVerified, ellers er testene uendret og applikasjonen skal funke som før.

🔒 **Sikkerhet / Trusselvurdering**

- Er det potensielle risikoer knyttet til endringen?
- Trengs det noen sikkerhetstiltak eller ytterligere vurderinger?
