### PR TITLE
Extract fly db config from env variables

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,1 +1,4 @@
 ALLOWED_CORS_HOSTS = "localhost:5173,localhost:5177"
+JDBC_URL = jdbc:postgresql://localhost:5432/frisk-backend-db
+DATABASE_USERNAME = postgres
+DATABASE_PASSWORD =

--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,5 @@ out/
 .DS_Store
 
 .env
-.env-local
+.env.local.secrets
+

--- a/fly.toml
+++ b/fly.toml
@@ -37,3 +37,7 @@ soft_limit = 100
 
 [env]
 ALLOWED_CORS_HOSTS = "frisk-frontend.fly.dev,localhost:5173"
+JDBC_URL = "jdbc:postgresql://${dbUri.host}:${dbUri.port}${dbUri.path}?sslmode=disable"
+DATABASE_USERNAME = ??
+# Settes inne på fly
+# DATABASE_PASSWORD =


### PR DESCRIPTION
**Beskrivelse**

🥅 Mål med PRen: Trekk ut databaseconf brukt i fly fra koden

**Løsning**

🆕 Endring: Databaseconfigen skal nå hentes basert på miljøvariablene JDBC_URL, DATABASE_USERNAME og DATABASE_PASSWORD i fly. Config i SKIP fortsetter på samme måte som før inntil vi får oppdatert frisk-backend i skip med nye miljøvariabler.

**🧪 Testing**

Vi må dobbelsjekke at databasen funker i fly etter merge til staging(?), og at config for SKIP forblir lik som før.

🔒 **Sikkerhet / Trusselvurdering**

- Er det potensielle risikoer knyttet til endringen?
- Trengs det noen sikkerhetstiltak eller ytterligere vurderinger?
