### PR TITLE
Remove skip db code

### DIFF
--- a/src/main/kotlin/com/kartverket/configuration/AppConfig.kt
+++ b/src/main/kotlin/com/kartverket/configuration/AppConfig.kt
@@ -1,7 +1,6 @@
 package com.kartverket.configuration
 
 import io.ktor.server.config.*
-import org.slf4j.LoggerFactory
 
 data class AppConfig(
     val functionHistoryCleanup: FunctionHistoryCleanupConfig,
@@ -26,7 +25,6 @@ data class AppConfig(
             )
         }
     }
-
 }
 
 data class FunctionHistoryCleanupConfig(
@@ -40,34 +38,11 @@ class DatabaseConfig(
     val password: String,
 ) {
     companion object {
-        private val logger = LoggerFactory.getLogger(DatabaseConfig::class.java)
-
-        fun load(): DatabaseConfig {
-            val env = System.getenv("environment")
-            val platform = System.getenv("platform")
-            return if (env == "production" && platform != "flyio") {
-                logger.info("Using gcp database configuration")
-
-                val skipJdbcUrl = "jdbc:postgresql://${
-                    System.getenv(
-                        "DATABASE_HOST",
-                    )
-                }:5432/frisk-backend-db?sslmode=require&sslrootcert=/app/db-ssl-ca/server-ca.pem$&sslcert=/app/db-ssl-ca/client-cert.pem&sslkey=/app/db-ssl-ca/client-key.pk8"
-                DatabaseConfig(
-                    jdbcUrl = skipJdbcUrl,
-                    username = "admin",
-                    password = System.getenv("DATABASE_PASSWORD") ?: ""
-                )
-            } else {
-                logger.info("Using local development database configuration")
-
-                DatabaseConfig(
-                    jdbcUrl = getConfigFromEnvOrThrow("JDBC_URL"),
-                    username = getConfigFromEnvOrThrow("DATABASE_USERNAME"),
-                    password = getConfigFromEnvOrThrow("DATABASE_PASSWORD")
-                )
-            }
-        }
+        fun load(): DatabaseConfig = DatabaseConfig(
+            jdbcUrl = getConfigFromEnvOrThrow("JDBC_URL"),
+            username = getConfigFromEnvOrThrow("DATABASE_USERNAME"),
+            password = getConfigFromEnvOrThrow("DATABASE_PASSWORD")
+        )
     }
 }
 


### PR DESCRIPTION
**Beskrivelse**

🥅 Mål med PRen: Fjern siste del av platform-spesifikk kode for SKIP

**Løsning**

🆕 Endring: Fjerner siste del av platform-spesifikk kode for skip, slik at databasekonfigurasjon nå styres av configverdier utenfor applikasjonen.

**🧪 Testing**

Sjekk at frisk-backend starter fint etter deploy til SKIP 🚢 

🔒 **Sikkerhet / Trusselvurdering**

- Er det potensielle risikoer knyttet til endringen?
- Trengs det noen sikkerhetstiltak eller ytterligere vurderinger?
