### PR TITLE
Flytt metadata til egne kolonner i datadump og skriv tester

### DIFF
--- a/src/main/kotlin/com/kartverket/Application.kt
+++ b/src/main/kotlin/com/kartverket/Application.kt
@@ -8,6 +8,8 @@ import com.kartverket.configuration.AppConfig
 import com.kartverket.configuration.FunctionHistoryCleanupConfig
 import com.kartverket.functions.FunctionService
 import com.kartverket.functions.FunctionServiceImpl
+import com.kartverket.functions.datadump.DataDumpService
+import com.kartverket.functions.datadump.DataDumpServiceImpl
 import com.kartverket.functions.metadata.FunctionMetadataService
 import com.kartverket.functions.metadata.FunctionMetadataServiceImpl
 import com.kartverket.microsoft.MicrosoftService
@@ -76,7 +78,8 @@ fun Application.module() {
     val functionService = FunctionServiceImpl(database)
     val functionMetadataService = FunctionMetadataServiceImpl(database, microsoftService)
     val authService = AuthServiceImpl(config.authConfig.superUserGroupId, functionMetadataService, microsoftService)
-    configureAPILayer(config, database, authService, functionService, functionMetadataService, microsoftService)
+    val dataDumpService = DataDumpServiceImpl(database)
+    configureAPILayer(config, authService, functionService, functionMetadataService, microsoftService, dataDumpService)
     launchCleanupJob(config.functionHistoryCleanup, database)
 
     environment.monitor.subscribe(ApplicationStopped) {
@@ -86,14 +89,14 @@ fun Application.module() {
 
 fun Application.configureAPILayer(
     config: AppConfig,
-    database: Database,
     authService: AuthService,
     functionService: FunctionService,
     functionMetadataService: FunctionMetadataService,
-    microsoftService: MicrosoftService
+    microsoftService: MicrosoftService,
+    dataDumpService: DataDumpService
 ) {
     configureSerialization()
     configureCors(config)
     configureAuth(config.authConfig)
-    configureRouting(database, authService, functionService, functionMetadataService, microsoftService)
+    configureRouting(authService, functionService, functionMetadataService, microsoftService, dataDumpService)
 }

--- a/src/main/kotlin/com/kartverket/JDBCDatabase.kt
+++ b/src/main/kotlin/com/kartverket/JDBCDatabase.kt
@@ -4,40 +4,17 @@ import com.kartverket.configuration.DatabaseConfig
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import io.ktor.util.logging.KtorSimpleLogger
-import kotlinx.serialization.Serializable
 import org.flywaydb.core.Flyway
 import java.sql.Connection
 import java.sql.PreparedStatement
-import java.sql.ResultSet
 
 interface Database {
-    fun getDump(): List<DumpRow>
     fun getConnection(): Connection
 }
 
 class JDBCDatabase(
     private val dataSource: HikariDataSource
 ) : Database {
-
-    override fun getDump(): List<DumpRow> {
-        val query =
-            """
-    select * from functions f
-    inner join function_metadata fm on fm.function_id = f.id
-    inner join function_metadata_keys fmk on fmk.id = fm.key_id
-""".trimIndent()
-        getConnection().use { connection ->
-            connection.prepareStatement(query).use { preparedStatement ->
-                val resultSet = preparedStatement.executeQuery()
-                return buildList {
-                    while (resultSet.next()) {
-                        add(resultSet.toDumpRow())
-                    }
-                }
-            }
-        }
-    }
-
     override fun getConnection(): Connection = dataSource.connection
 
     fun closePool() {
@@ -88,28 +65,3 @@ inline fun <T> Database.useStatement(query: String, block: (statement: PreparedS
         connection.prepareStatement(query).use(block)
     }
 }
-
-private fun ResultSet.toDumpRow(): DumpRow {
-    return DumpRow(
-        id = getInt("id"),
-        parentId = getInt("parent_id"),
-        name = getString("name"),
-        description = getString("description"),
-        path = getString("path"),
-        key = getString("key"),
-        value = getString("value")
-    )
-}
-
-
-
-@Serializable
-data class DumpRow(
-    val id: Int,
-    val name: String,
-    val description: String?,
-    val parentId: Int?,
-    val path: String,
-    val key: String,
-    val value: String,
-)

--- a/src/main/kotlin/com/kartverket/functions/datadump/DataDumpRoutes.kt
+++ b/src/main/kotlin/com/kartverket/functions/datadump/DataDumpRoutes.kt
@@ -1,0 +1,57 @@
+package com.kartverket.functions.datadump
+
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.util.logging.*
+
+val logger = KtorSimpleLogger("DataDumpRoutes")
+
+fun Route.dataDumpRoutes(
+    dataDumpService: DataDumpService
+) {
+    route("/dump") {
+        get {
+            logger.info("Received get on /dump")
+            val fileName = "data.csv"
+
+            call.response.header(
+                HttpHeaders.ContentDisposition,
+                ContentDisposition.Attachment.withParameter(ContentDisposition.Parameters.FileName, fileName).toString()
+            )
+            val datadump = dataDumpService.getDataDump()
+            val datadumpCsv = datadump.toCsv()
+
+            call.respondBytes(
+                bytes = datadumpCsv.toByteArray(Charsets.UTF_8),
+                contentType = ContentType.Text.CSV.withCharset(Charsets.UTF_8)
+            )
+        }
+    }
+}
+
+fun List<DumpRow>.toCsv(): String {
+    val headers = mutableSetOf("id", "name", "description", "path")
+    for (row in this) {
+        headers.addAll(row.metadata.keys)
+    }
+    val headerList = headers.toList()
+
+    return buildString {
+        appendLine(headerList.joinToString(","))
+
+        for (row in this@toCsv) {
+            appendLine(headerList.joinToString(",") { column ->
+                val value = when (column) {
+                    "id" -> row.id.toString()
+                    "name" -> row.name
+                    "description" -> row.description ?: ""
+                    "path" -> row.path
+                    else -> row.metadata[column] ?: ""
+                }
+                "\"${value.replace("\"", "\"\"")}\""
+            })
+        }
+    }
+}

--- a/src/main/kotlin/com/kartverket/functions/datadump/DataDumpRoutes.kt
+++ b/src/main/kotlin/com/kartverket/functions/datadump/DataDumpRoutes.kt
@@ -32,7 +32,7 @@ fun Route.dataDumpRoutes(
 }
 
 fun List<DumpRow>.toCsv(): String {
-    val headers = mutableSetOf("id", "name", "description", "path")
+    val headers = mutableSetOf("id", "name", "path")
     for (row in this) {
         headers.addAll(row.metadata.keys)
     }
@@ -46,7 +46,6 @@ fun List<DumpRow>.toCsv(): String {
                 val value = when (column) {
                     "id" -> row.id.toString()
                     "name" -> row.name
-                    "description" -> row.description ?: ""
                     "path" -> row.path
                     else -> row.metadata[column] ?: ""
                 }

--- a/src/main/kotlin/com/kartverket/functions/datadump/DataDumpService.kt
+++ b/src/main/kotlin/com/kartverket/functions/datadump/DataDumpService.kt
@@ -9,7 +9,6 @@ import java.sql.ResultSet
 data class DumpRow(
     val id: Int,
     val name: String,
-    val description: String?,
     val parentId: Int?,
     val path: String,
     val metadata: Map<String, String>
@@ -27,7 +26,6 @@ class DataDumpServiceImpl(
             WITH data_raw AS (
                     SELECT f.id AS function_id,
                            f.name,
-                           f.description,
                            f.parent_id,
                            f.path,
                            fmk.key AS metadata_key_name,
@@ -36,10 +34,10 @@ class DataDumpServiceImpl(
                              INNER JOIN function_metadata fm ON fm.function_id = f.id
                              INNER JOIN function_metadata_keys fmk ON fmk.id = fm.key_id
                 )
-                SELECT function_id, name, description, parent_id, path,
+                SELECT function_id, name, parent_id, path,
                        jsonb_object_agg(metadata_key_name, metadata_value) AS metadata
                 FROM data_raw
-                GROUP BY function_id, name, description, parent_id, path
+                GROUP BY function_id, name, parent_id, path
         """.trimIndent()
 
         database.useStatement(query) { statement ->
@@ -57,7 +55,6 @@ class DataDumpServiceImpl(
             id = getInt("function_id"),
             parentId = getInt("parent_id"),
             name = getString("name"),
-            description = getString("description"),
             path = getString("path"),
             metadata = parseMetadata(getString("metadata")),
         )

--- a/src/main/kotlin/com/kartverket/functions/datadump/DataDumpService.kt
+++ b/src/main/kotlin/com/kartverket/functions/datadump/DataDumpService.kt
@@ -1,0 +1,74 @@
+package com.kartverket.functions.datadump
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.kartverket.Database
+import com.kartverket.useStatement
+import java.sql.ResultSet
+
+data class DumpRow(
+    val id: Int,
+    val name: String,
+    val description: String?,
+    val parentId: Int?,
+    val path: String,
+    val metadata: Map<String, String>
+)
+
+interface DataDumpService {
+    fun getDataDump() : List<DumpRow>
+}
+
+class DataDumpServiceImpl(
+    private val database: Database
+): DataDumpService {
+    override fun getDataDump(): List<DumpRow> {
+        val query ="""
+            WITH data_raw AS (
+                    SELECT f.id AS function_id,
+                           f.name,
+                           f.description,
+                           f.parent_id,
+                           f.path,
+                           fmk.key AS metadata_key_name,
+                           fm.value AS metadata_value
+                    FROM functions f
+                             INNER JOIN function_metadata fm ON fm.function_id = f.id
+                             INNER JOIN function_metadata_keys fmk ON fmk.id = fm.key_id
+                )
+                SELECT function_id, name, description, parent_id, path,
+                       jsonb_object_agg(metadata_key_name, metadata_value) AS metadata
+                FROM data_raw
+                GROUP BY function_id, name, description, parent_id, path
+        """.trimIndent()
+
+        database.useStatement(query) { statement ->
+            val resultSet = statement.executeQuery()
+            return buildList {
+                while (resultSet.next()) {
+                    add(resultSet.toDumpRow())
+                }
+            }.sortedBy { it.id }
+        }
+    }
+
+    private fun ResultSet.toDumpRow(): DumpRow {
+        return DumpRow(
+            id = getInt("function_id"),
+            parentId = getInt("parent_id"),
+            name = getString("name"),
+            description = getString("description"),
+            path = getString("path"),
+            metadata = parseMetadata(getString("metadata")),
+        )
+    }
+
+    private fun parseMetadata(metadataJson: String?): Map<String, String> {
+        return if (!metadataJson.isNullOrBlank()) {
+            ObjectMapper().readValue(metadataJson, object : TypeReference<Map<String, String>>() {})
+        } else {
+            emptyMap()
+        }
+    }
+}
+

--- a/src/main/kotlin/com/kartverket/plugins/Routing.kt
+++ b/src/main/kotlin/com/kartverket/plugins/Routing.kt
@@ -1,6 +1,5 @@
 package com.kartverket.plugins
 
-import com.kartverket.Database
 import com.kartverket.auth.AUTH_JWT
 import com.kartverket.auth.AuthService
 import com.kartverket.functions.FunctionService

--- a/src/test/kotlin/com/kartverket/ApplicationTest.kt
+++ b/src/test/kotlin/com/kartverket/ApplicationTest.kt
@@ -5,6 +5,7 @@ import com.kartverket.configuration.DatabaseConfig
 import com.kartverket.configuration.EntraConfig
 import com.kartverket.configuration.FunctionHistoryCleanupConfig
 import com.kartverket.functions.FunctionServiceImpl
+import com.kartverket.functions.datadump.DataDumpServiceImpl
 import com.kartverket.functions.metadata.FunctionMetadataServiceImpl
 import io.ktor.client.request.*
 import io.ktor.http.*
@@ -30,11 +31,11 @@ class ApplicationTest {
             val mockDatabase = object : MockDatabase {}
             configureAPILayer(
                 exampleConfig,
-                mockDatabase,
                 object : MockAuthService {},
                 FunctionServiceImpl(mockDatabase),
                 FunctionMetadataServiceImpl(mockDatabase, object : MockMicrosoftService {}),
-                object : MockMicrosoftService {}
+                object : MockMicrosoftService {},
+                DataDumpServiceImpl(mockDatabase)
             )
             routing {
                 val publicEndpointsRegexList = listOf(
@@ -80,11 +81,11 @@ class ApplicationTest {
                 exampleConfig.copy(
                     allowedCORSHosts = listOf("test.com")
                 ),
-                mockDatabase,
                 object : MockAuthService {},
                 FunctionServiceImpl(mockDatabase),
                 FunctionMetadataServiceImpl(mockDatabase, object : MockMicrosoftService {}),
-                object : MockMicrosoftService {}
+                object : MockMicrosoftService {},
+                DataDumpServiceImpl(mockDatabase)
             )
         }
 

--- a/src/test/kotlin/com/kartverket/MockDatabase.kt
+++ b/src/test/kotlin/com/kartverket/MockDatabase.kt
@@ -3,6 +3,5 @@ package com.kartverket
 import java.sql.Connection
 
 interface MockDatabase : Database {
-    override fun getDump(): List<DumpRow> = TODO("Not yet implemented")
     override fun getConnection(): Connection = TODO("Not yet implemented")
 }

--- a/src/test/kotlin/com/kartverket/TestDatabase.kt
+++ b/src/test/kotlin/com/kartverket/TestDatabase.kt
@@ -1,9 +1,6 @@
 package com.kartverket
 
 import com.kartverket.configuration.DatabaseConfig
-import com.zaxxer.hikari.HikariConfig
-import com.zaxxer.hikari.HikariDataSource
-import org.flywaydb.core.Flyway
 import org.testcontainers.containers.PostgreSQLContainer
 
 class TestDatabase {

--- a/src/test/kotlin/com/kartverket/TestUtils.kt
+++ b/src/test/kotlin/com/kartverket/TestUtils.kt
@@ -2,16 +2,18 @@ package com.kartverket
 
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
-import com.kartverket.functions.dto.CreateFunctionDto
-import com.kartverket.functions.dto.CreateFunctionWithMetadataDto
+import com.kartverket.auth.AUTH_JWT
+import com.kartverket.auth.AuthService
 import com.kartverket.functions.Function
 import com.kartverket.functions.FunctionService
 import com.kartverket.functions.FunctionServiceImpl
-import com.kartverket.functions.metadata.dto.CreateFunctionMetadataDTO
+import com.kartverket.functions.datadump.DataDumpService
+import com.kartverket.functions.datadump.DataDumpServiceImpl
+import com.kartverket.functions.dto.CreateFunctionDto
+import com.kartverket.functions.dto.CreateFunctionWithMetadataDto
 import com.kartverket.functions.metadata.FunctionMetadataService
-import com.kartverket.auth.AUTH_JWT
-import com.kartverket.auth.AuthService
 import com.kartverket.functions.metadata.FunctionMetadataServiceImpl
+import com.kartverket.functions.metadata.dto.CreateFunctionMetadataDTO
 import com.kartverket.microsoft.MicrosoftService
 import com.kartverket.plugins.configureRouting
 import com.kartverket.plugins.configureSerialization
@@ -37,6 +39,7 @@ object TestUtils {
             testDatabase,
             microsoftService
         ),
+        dataDumpService: DataDumpService = DataDumpServiceImpl(testDatabase)
     ) {
         configureSerialization()
 
@@ -54,7 +57,13 @@ object TestUtils {
             }
         }
 
-        configureRouting(testDatabase, authService, functionService, functionMetadataService, microsoftService)
+        configureRouting(
+            authService,
+            functionService,
+            functionMetadataService,
+            microsoftService,
+            dataDumpService
+        )
     }
 
     fun generateTestToken(): String {

--- a/src/test/kotlin/com/kartverket/functions/datadump/DataDumpRoutesTest.kt
+++ b/src/test/kotlin/com/kartverket/functions/datadump/DataDumpRoutesTest.kt
@@ -1,0 +1,29 @@
+package com.kartverket.functions.datadump
+
+import com.kartverket.TestUtils.generateTestToken
+import com.kartverket.TestUtils.testModule
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.server.testing.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class DataDumpRoutesTest {
+
+    @Test
+    fun `get dump`() = testApplication {
+        application {
+            testModule(dataDumpService = object : MockDataDumpService {
+                override fun getDataDump(): List<DumpRow> {
+                    return emptyList()
+                }
+            })
+        }
+
+        val response = client.get("/dump") {
+            header(HttpHeaders.Authorization, "Bearer ${generateTestToken()}")
+        }
+        assertEquals(HttpStatusCode.OK, response.status)
+
+    }
+}

--- a/src/test/kotlin/com/kartverket/functions/datadump/DataDumpServiceTest.kt
+++ b/src/test/kotlin/com/kartverket/functions/datadump/DataDumpServiceTest.kt
@@ -1,0 +1,71 @@
+package com.kartverket.functions.datadump
+
+import com.kartverket.Database
+import com.kartverket.JDBCDatabase
+import com.kartverket.MockMicrosoftService
+import com.kartverket.TestDatabase
+import com.kartverket.functions.FunctionServiceImpl
+import com.kartverket.functions.dto.CreateFunctionDto
+import com.kartverket.functions.metadata.FunctionMetadataServiceImpl
+import com.kartverket.functions.metadata.dto.CreateFunctionMetadataDTO
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import java.util.*
+
+class DataDumpServiceTest {
+
+    @Test
+    fun `fetch data dump`() {
+        val dataDumpService = DataDumpServiceImpl(database)
+        val functionService = FunctionServiceImpl(database)
+        val microsoftService = object : MockMicrosoftService {}
+        val functionMetadataService = FunctionMetadataServiceImpl(database, microsoftService)
+
+        // Create function
+        val functionName = "${UUID.randomUUID()}"
+        val createFunctionDto = CreateFunctionDto(
+            name = functionName, description = "desc", parentId = 1
+        )
+        val createdFunction = functionService.createFunction(createFunctionDto)!!
+        val fetchedFunction = functionService.getFunction(createdFunction.id)
+        assertEquals(createdFunction, fetchedFunction)
+
+        // Create metadata for function
+        val createFunctionMetadataDTO1 = CreateFunctionMetadataDTO(key = "beskrivelse", value = "Her er en beskrivelse")
+        val createFunctionMetadataDTO2 = CreateFunctionMetadataDTO(key = "kritikalitet", value = "Høy")
+        functionMetadataService.addMetadataToFunction(createdFunction.id, createFunctionMetadataDTO1)
+        functionMetadataService.addMetadataToFunction(createdFunction.id, createFunctionMetadataDTO2)
+        val fetchedMetdata = functionMetadataService.getFunctionMetadataById(1)
+        assertEquals(fetchedMetdata?.key, createFunctionMetadataDTO1.key)
+        assertEquals(fetchedMetdata?.value, createFunctionMetadataDTO1.value)
+        assertEquals(fetchedMetdata?.functionId, createdFunction.id)
+
+        // Fetch data dump
+        val dataDump = dataDumpService.getDataDump()
+        val expectedMetadata = mapOf("beskrivelse" to "Her er en beskrivelse", "kritikalitet" to "Høy")
+        val expectedResponse = listOf(DumpRow(fetchedFunction!!.id, functionName, 1, "1.2", expectedMetadata))
+        assertEquals(expectedResponse, dataDump)
+
+    }
+
+
+    companion object {
+        private lateinit var testDatabase: TestDatabase
+        private lateinit var database: Database
+
+        @JvmStatic
+        @BeforeAll
+        fun setup() {
+            testDatabase = TestDatabase()
+            database = JDBCDatabase.create(testDatabase.getTestdatabaseConfig())
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun stopDatabase() {
+            testDatabase.stopTestDatabase()
+        }
+    }
+}

--- a/src/test/kotlin/com/kartverket/functions/datadump/MockDataDumpService.kt
+++ b/src/test/kotlin/com/kartverket/functions/datadump/MockDataDumpService.kt
@@ -1,0 +1,3 @@
+package com.kartverket.functions.datadump
+
+interface MockDataDumpService : DataDumpService {}


### PR DESCRIPTION
**Beskrivelse**

🥅 Mål med PRen: *Hvorfor er oppgaven laget og hvilke problem løser denne PRen?*
Rotete i csv-fila, og ønskelig at metadata skal være i sine egne kolonner så det kun blir en rad per funksjonsid. 

**Løsning**

🆕 Endring: *Skriv kort hva endringen i denne PRen er og hvorfor den har løst problemet.*
Fjernet ubrukte variabler fra spørringen, og skrevet den om slik at metadata blir en map<string,string>. Dette gjør at spørringen blir generisk og skal kunne funke med alt av metadata. Når det mappes til egne kolonner i csv, så leser den gjennom listen og generer ut i fra key-navnene. 

Har også flyttet logikken til egnen mappe med route og service, og skrevet tester. 


**🧪 Testing**

*Er det noe spesielt den som reviewer PRen bør sjekke?*

🔒 **Sikkerhet / Trusselvurdering**

- Er det potensielle risikoer knyttet til endringen?
- Trengs det noen sikkerhetstiltak eller ytterligere vurderinger?
