### PR TITLE
only trigger fly deploy on merge

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -149,6 +149,7 @@ jobs:
 
   deploy-fly:
     name: Deploy app
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     concurrency: deploy-group    # optional: ensure only one action runs at a time
     needs: [tests]


### PR DESCRIPTION
**Beskrivelse**

🥅 Mål med PRen: 
Hvis jeg skjønner riktig så trigges deploy til fly når en PR blir opprettet, og vi vil at den trigges når PR'en merges

**Løsning**

🆕 Endring: 
La til en if slik at deploy til fly kjøres kun etter merge, samme if-setning som i deploy-dev

**🧪 Testing**

*Er det noe spesielt den som reviewer PRen bør sjekke?*

🔒 **Sikkerhet / Trusselvurdering**

- Er det potensielle risikoer knyttet til endringen?
- Trengs det noen sikkerhetstiltak eller ytterligere vurderinger?
