### PR TITLE
Fix security vulnerabilities from Dependabot alerts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,7 +68,6 @@ dependencies {
     implementation("io.ktor:ktor-server-auth-jwt:$ktor_version")
     implementation("io.ktor:ktor-server-swagger:$ktor_version")
     implementation("com.azure:azure-identity:1.18.1")
-    implementation("net.minidev:json-smart:2.6.0") /* kan slettes når Azure oppdaterer denne selv*/
     implementation("com.microsoft.graph:microsoft-graph:$microsoft_graph_version")
     implementation("io.ktor:ktor-client-core:$ktor_version")
     implementation("io.ktor:ktor-client-cio:$ktor_version")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,8 +38,14 @@ repositories {
 
 configurations.all {
     resolutionStrategy.eachDependency {
-        if (requested.group == "io.netty" && requested.name == "netty-codec-http2") {
-            useVersion("4.2.4.Final") // Sårbarhet i io.netty:netty-codec-http2. 2025-08-20
+        if (requested.group == "io.netty" && requested.name in listOf("netty-codec-http2", "netty-codec-http", "netty-codec-compression")) {
+            useVersion("4.2.10.Final") // Sårbarhet i io.netty (CVE CRLF-injection, DoS). 2026-03-02
+        }
+        if (requested.group == "org.apache.commons" && requested.name == "commons-compress") {
+            useVersion("1.28.0") // Sårbarhet i org.apache.commons:commons-compress (DoS). 2026-03-02
+        }
+        if (requested.group == "org.apache.logging.log4j" && requested.name == "log4j-core") {
+            useVersion("2.25.3") // Sårbarhet i org.apache.logging.log4j:log4j-core (TLS hostname). 2026-03-02
         }
     }
 }
@@ -62,7 +68,7 @@ dependencies {
     implementation("io.ktor:ktor-server-auth-jwt:$ktor_version")
     implementation("io.ktor:ktor-server-swagger:$ktor_version")
     implementation("com.azure:azure-identity:1.18.1")
-    implementation("net.minidev:json-smart:2.5.2") /* kan slettes når Azure oppdaterer denne selv*/
+    implementation("net.minidev:json-smart:2.6.0") /* kan slettes når Azure oppdaterer denne selv*/
     implementation("com.microsoft.graph:microsoft-graph:$microsoft_graph_version")
     implementation("io.ktor:ktor-client-core:$ktor_version")
     implementation("io.ktor:ktor-client-cio:$ktor_version")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 kotlin.code.style=official
 ktor_version=3.2.3
 kotlin_version=2.2.10
-logback_version=1.5.18
+logback_version=1.5.32
 postgres_version=42.7.7
 h2_version=2.3.232


### PR DESCRIPTION
## Security fixes

Addresses all open Dependabot security alerts:

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #21, #24 | `ch.qos.logback:logback-core` | medium/low | Updated `logback_version` from 1.5.18 → 1.5.32 |
| #17, #19, #22 | `io.netty:netty-codec-http`, `netty-codec-http2`, `netty-codec-compression` | medium/low | Forced all three to 4.2.10.Final via resolution strategy |
| #1, #3 | `org.apache.commons:commons-compress` | medium | Forced to 1.28.0 via resolution strategy |
| #23 | `org.apache.logging.log4j:log4j-core` | medium | Forced to 2.25.3 via resolution strategy |
| PR #249 | `net.minidev:json-smart` | - | Bumped from 2.5.2 → 2.6.0 |

## Testing
- Compilation verified ✅
- Unit tests pass ✅  
- Integration tests require Docker (TestContainers) and fail in local env — pre-existing environment issue, not related to these changes.